### PR TITLE
Fix broken totalCount processing for invite pagination

### DIFF
--- a/src/lib/components/achievement/ClaimList.svelte
+++ b/src/lib/components/achievement/ClaimList.svelte
@@ -56,7 +56,7 @@
 		if (category == 'AchievementClaim') claims = responseJson.data;
 		else {
 			outstandingInvites = responseJson.data;
-			if (responseJson.meta?.count) inviteCount = responseJson.meta.count;
+			if (responseJson.meta?.totalCount) inviteCount = responseJson.meta.totalCount;
 		}
 		loading = false;
 	};

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -4,8 +4,6 @@ import { error, json } from '@sveltejs/kit';
 
 type ApiMetaInput = PaginationData & {
 	type: string;
-	page: number;
-	pageSize: number;
 	totalCount?: number;
 	totalPages?: number;
 	getTotalCount?: () => Promise<number>;

--- a/src/routes/api/[[version]]/achievementClaims/+server.ts
+++ b/src/routes/api/[[version]]/achievementClaims/+server.ts
@@ -15,7 +15,7 @@ export const GET = async ({ url, params, locals }: RequestEvent) => {
 	}
 
 	const editAchievementCapability = locals.session?.user?.orgRole == 'GENERAL_ADMIN';
-	const { page, pageSize } = calculatePageAndSize(url);
+	const { page, pageSize, includeCount } = calculatePageAndSize(url);
 	const claims = await prisma.achievementClaim.findMany({
 		where: {
 			achievementId: achievementId,
@@ -43,6 +43,7 @@ export const GET = async ({ url, params, locals }: RequestEvent) => {
 		data: claims,
 		meta: {
 			type: 'AchievementClaim',
+			includeCount,
 			getTotalCount: async () => {
 				return await prisma.achievementClaim.count({
 					where: {

--- a/src/routes/api/[[version]]/achievements/[id]/invites/+server.ts
+++ b/src/routes/api/[[version]]/achievements/[id]/invites/+server.ts
@@ -41,7 +41,7 @@ export const GET = async ({ url, params, locals }: RequestEvent) => {
 						achievementId: achievementId,
 						organizationId: locals.org.id,
 						claimId: null,
-						...(isAdmin ? {} : { creatorId: locals.session.user.id })
+						...(isAdmin ? {} : { creatorId: locals.session?.user?.id })
 					}
 				});
 			},


### PR DESCRIPTION
The correct parameter in responseJson.meta is `totalCount`.