### PR TITLE
Fix form-based award invocation

### DIFF
--- a/src/routes/achievements/[id]/award/+page.server.ts
+++ b/src/routes/achievements/[id]/award/+page.server.ts
@@ -58,6 +58,6 @@ export const actions = {
 			} as App.EvidenceItem)
 		};
 		const result = await inviteToClaim(claimData);
-		return result;
+		return result.data;
 	}
 } satisfies Actions;


### PR DESCRIPTION
The API based invocation and the Form based invocation are different in that the form Actions automatically wrap the data element.