### PR TITLE
Fix form-based award invocation

### DIFF
--- a/src/routes/achievements/categories/+page.server.ts
+++ b/src/routes/achievements/categories/+page.server.ts
@@ -50,7 +50,7 @@ export const actions: Actions = {
 		// Can only search by unique inputs on update, so verify first this category is in this org
 		const existingCategory = await prisma.achievementCategory.findFirstOrThrow({
 			where: {
-				organization: locals.org,
+				organizationId: locals.org.id,
 				id: categoryId
 			}
 		});
@@ -76,7 +76,7 @@ export const actions: Actions = {
 		// Can only search by unique inputs on update, so verify first this category is in this org
 		const existingCategory = await prisma.achievementCategory.findFirstOrThrow({
 			where: {
-				organization: locals.org,
+				organizationId: locals.org.id,
 				id: categoryId
 			}
 		});

--- a/src/routes/api/[[version]]/backpack/claims/+server.ts
+++ b/src/routes/api/[[version]]/backpack/claims/+server.ts
@@ -28,7 +28,7 @@ export const GET: RequestHandler = async ({ url, request, params, locals }) => {
 			type: 'Achievement',
 			getTotalCount: () =>
 				prisma.achievementClaim.count({
-					where: { organizationId: locals.org.id, userId: locals.session.user.id }
+					where: { organizationId: locals.org.id, userId: locals.session?.user?.id }
 				}),
 			page,
 			pageSize,


### PR DESCRIPTION
Search based on the organizationId field specifically.

This fixes a bug with editing categories, because prisma couldn't accept org data with "tagline" (which is in the json)