### PR TITLE
Fixes a case of resetting admin review requirement

### DIFF
--- a/src/lib/partials/AchievementForm.svelte
+++ b/src/lib/partials/AchievementForm.svelte
@@ -392,7 +392,11 @@
 					<AchievementSelect
 						badgeId={formData.reviewRequires}
 						on:unselected={() => {
-							formData.reviewableSelectedOption = 'none';
+							if (formData.reviewableSelectedOption == 'badge') {
+								// only unselect if something a badge selected
+								// not "admin"
+								formData.reviewableSelectedOption = 'none';
+							}
 							formData.reviewRequires = null;
 						}}
 						on:selected={(e) => {


### PR DESCRIPTION
If "admin" is selected, the deselect badge-type event shouldn't invalidate that selection.