### PR TITLE
Fix: Unreviewed Prereq badge granted access to further claims

### DIFF
--- a/src/lib/data/achievementClaim.ts
+++ b/src/lib/data/achievementClaim.ts
@@ -16,6 +16,34 @@ export const getUserClaim = async (
 	});
 };
 
+/**
+ * Get a user's valid claim for an achievement.
+ * A claim is considered valid if it:
+ * - Has been reviewed/approved (validFrom is set)
+ * - Is accepted (claimStatus is 'ACCEPTED')
+ * - Has not expired (validUntil is null or in the future)
+ * - Belongs to the specified organization
+ */
+export const getValidUserClaim = async (
+	userId: string,
+	achievementId: string,
+	organizationId: string
+) => {
+	return await prisma.achievementClaim.findFirst({
+		where: {
+			userId,
+			achievementId,
+			organizationId,
+			validFrom: { not: null }, // Claim must be approved
+			claimStatus: 'ACCEPTED', // Claim must be accepted
+			OR: [
+				{ validUntil: null }, // No expiration
+				{ validUntil: { gt: new Date() } } // Not yet expired
+			]
+		}
+	});
+};
+
 interface EvidenceItem {
 	narrative?: string;
 	id?: string;

--- a/src/routes/achievements/[id]/+page.svelte
+++ b/src/routes/achievements/[id]/+page.svelte
@@ -70,7 +70,13 @@
 		config = data.achievement.achievementConfig as App.AchievementConfig | null;
 		claim = data.relatedClaims.find((c) => data.achievement.id == c.achievementId);
 		userHoldsRequiredAchievement =
-			data.relatedClaims.filter((c) => c.achievementId == config?.claimRequiresId).length > 0;
+			data.relatedClaims.filter(
+				(c) =>
+					c.achievementId == config?.claimRequiresId &&
+					c.validFrom !== null &&
+					c.claimStatus === 'ACCEPTED' &&
+					(c.validUntil === null || new Date(c.validUntil) > new Date())
+			).length > 0;
 		inviteCapability =
 			isAdmin({ user: data.session?.user || undefined }) ||
 			(!!config?.json?.capabilities?.inviteRequires &&

--- a/src/routes/claims/[claimId]/+page.server.ts
+++ b/src/routes/claims/[claimId]/+page.server.ts
@@ -4,7 +4,7 @@ import { error, redirect } from '@sveltejs/kit';
 import { prisma } from '$lib/../prisma/client';
 
 import { getAchievement } from '$lib/data/achievement';
-import { getUserClaim } from '$lib/data/achievementClaim';
+import { getUserClaim, getValidUserClaim } from '$lib/data/achievementClaim';
 
 const throwRedirect = (url: URL) => {
 	throw redirect(307, `${url}/public`);
@@ -43,7 +43,7 @@ export const load: PageServerLoad = async ({ locals, params, url }) => {
 	// have a claim.
 	const prerequisiteClaim =
 		!claim && config?.claimable && config?.claimRequiresId && locals.session?.user.id
-			? await getUserClaim(locals.session?.user.id, config?.claimRequiresId, locals.org.id)
+			? await getValidUserClaim(locals.session?.user.id, config?.claimRequiresId, locals.org.id)
 			: null;
 
 	return {


### PR DESCRIPTION
Resolves #38

Users can claim the "Member" achievement (which requires review) and immediately use it as a prerequisite to claim other badges, even though the claim hasn't been reviewed/approved yet. The prerequisite check only verifies claim existence, not validity.

Root Cause

The getUserClaim() function in [src/lib/data/achievementClaim.ts](src/lib/data/achievementClaim.ts) returns any claim without validating:

* validFrom is set (claim has been reviewed/approved)
* claimStatus is 'ACCEPTED'
* Claim hasn't expired (validUntil is null or in the future)

This function is used in prerequisite checks in:
`src/routes/achievements/[id]/claim/+page.server.ts` (lines 38-41, 87-90)
`src/routes/claims/[claimId]/+page.server.ts` (lines 44-47)


