### PR TITLE
feat(healthz): Don't require org for healthcheck domain

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -76,8 +76,13 @@ const getAuthHeaderTokenValue = function (authHeader: string | null) {
 	return parts[1];
 };
 
-export const handle: Handle = ({ event, resolve }) =>
-	paraglideMiddleware(event.request, async ({ request: localizedRequest }) => {
+export const handle: Handle = ({ event, resolve }) => {
+	// Short-circuit for healthcheck - no org validation needed
+	if (event.url.pathname === '/healthz') {
+		return resolve(event);
+	}
+
+	return paraglideMiddleware(event.request, async ({ request: localizedRequest }) => {
 		event.request = localizedRequest;
 
 		event.locals.org = await getOrganizationFromRequest(event);
@@ -122,3 +127,4 @@ export const handle: Handle = ({ event, resolve }) =>
 
 		return response;
 	});
+};

--- a/src/routes/healthz/+server.ts
+++ b/src/routes/healthz/+server.ts
@@ -1,3 +1,13 @@
 import { json } from '@sveltejs/kit';
+import { prisma } from '../../prisma/client';
 
-export const GET = () => json({ healthy: true });
+export const GET = async () => {
+	try {
+		// Verify database connectivity with a lightweight query
+		await prisma.$queryRaw`SELECT 1`;
+		return json({ healthy: true });
+	} catch {
+		// Database is not reachable - return 503 Service Unavailable
+		return json({ healthy: false }, { status: 503 });
+	}
+};


### PR DESCRIPTION
In some situations, the system can start up and the healthcheck URL might be `http://127.0.0.1/healthz` or `http://localhost:3000/healthz` or `http://:1:3000/healthz`. We do a database check within, but don't require the selected domain to be an existing domain for the org in the database, also serving the use case that the org has not been set up yet by the time healthz runs.