### PR TITLE
fix(transactionService): use Basic auth and parse possible exchangeId

### DIFF
--- a/src/lib/server/transactionService/client.test.ts
+++ b/src/lib/server/transactionService/client.test.ts
@@ -56,25 +56,25 @@ describe('createExchange', () => {
 	});
 
 	const okProtocolsBody = {
-		iu: '1',
-		vcapi: '2',
-		lcw: '3',
+		iu: 'https://host.example/interactions/ex-abc-123',
+		vcapi: 'https://host.example/workflows/claim/exchanges/ex-abc-123',
+		lcw: 'https://lcw.app/request?vcapi=https://host.example/workflows/claim/exchanges/ex-abc-123',
 		verifiablePresentationRequest: {}
 	};
 
-	it('returns exchangeId, protocols (four fields), and expiresAt in the ~10m window', async () => {
+	it('returns exchangeId parsed from iu, protocols (four fields), and expiresAt in the ~10m window', async () => {
 		const t0 = Date.now();
 		const ucProtocols = {
-			iu: 'https://i',
-			vcapi: 'https://v',
-			lcw: 'https://l',
+			iu: 'https://host.example/interactions/my-exchange-id',
+			vcapi: 'https://host.example/workflows/claim/exchanges/my-exchange-id',
+			lcw: 'https://lcw.app/request?vcapi=...',
 			verifiablePresentationRequest: { foo: 'bar' }
 		};
 		mockFetch.mockResolvedValue(okResponse(ucProtocols));
 
 		const result = await createExchange(baseOrg(), { vc: { a: 1 } });
 
-		expect(result.exchangeId).toBe('TODO');
+		expect(result.exchangeId).toBe('my-exchange-id');
 		expect(result.protocols).toEqual(ucProtocols);
 		const exp = new Date(result.expiresAt).getTime();
 		const minT = t0 + 9.5 * 60 * 1000;
@@ -95,18 +95,44 @@ describe('createExchange', () => {
 		});
 	});
 
-	it("sets Authorization to Bearer and the fixture's decrypted API key", async () => {
+	it('sets Authorization to Basic with base64-encoded tenantName:apiKey', async () => {
 		mockFetch.mockResolvedValue(okResponse(okProtocolsBody));
 		await createExchange(baseOrg(), { vc: {} });
 
 		const init = mockFetch.mock.calls[0][1]!;
-		expect((init.headers as Record<string, string>).Authorization).toBe('Bearer plaintext-api-key');
+		const expectedCredentials = Buffer.from('my-tenant:plaintext-api-key').toString('base64');
+		expect((init.headers as Record<string, string>).Authorization).toBe(
+			`Basic ${expectedCredentials}`
+		);
 	});
 
 	it("normalizes URL to 'https://ts.example.com/workflows/claim/exchanges' without a trailing segment slash", async () => {
 		mockFetch.mockResolvedValue(okResponse(okProtocolsBody));
 		await createExchange(baseOrg(), { vc: {} });
 		expect(mockFetch.mock.calls[0][0]).toBe('https://ts.example.com/workflows/claim/exchanges');
+	});
+
+	it('prefers a direct id field over parsing the iu URL', async () => {
+		mockFetch.mockResolvedValue(
+			okResponse({ id: 'direct-id', ...okProtocolsBody })
+		);
+		const result = await createExchange(baseOrg(), { vc: {} });
+		expect(result.exchangeId).toBe('direct-id');
+		expect(result.protocols.iu).toBe(okProtocolsBody.iu);
+	});
+
+	it('handles a future nested protocols shape with top-level id', async () => {
+		mockFetch.mockResolvedValue(
+			okResponse({
+				id: 'nested-id',
+				sequence: 0,
+				state: 'pending',
+				protocols: okProtocolsBody
+			})
+		);
+		const result = await createExchange(baseOrg(), { vc: {} });
+		expect(result.exchangeId).toBe('nested-id');
+		expect(result.protocols).toEqual(okProtocolsBody);
 	});
 
 	it('throws TransactionServiceUpstreamError with status on non-2xx', async () => {

--- a/src/lib/server/transactionService/client.ts
+++ b/src/lib/server/transactionService/client.ts
@@ -55,7 +55,7 @@ export async function createExchange(
 		response = await redactedFetch(url, {
 			method: 'POST',
 			headers: {
-				Authorization: `Bearer ${apiKey}`,
+				Authorization: `Basic ${Buffer.from(`${transactionService.tenantName}:${apiKey}`).toString('base64')}`,
 				'Content-Type': 'application/json',
 				Accept: 'application/json'
 			},
@@ -87,27 +87,15 @@ export async function createExchange(
 	}
 
 	const data = (await response.json()) as Record<string, unknown>;
-
-	// TODO: Later we will implement polling, and the transaction service will need to return
-	// the relevent exchange iD.
-	// const rawId = data.id;
-	// if (typeof rawId !== 'string' || rawId.length === 0) {
-	// 	throw new TransactionServiceUpstreamError('Missing exchange id in response', {
-	// 		status: response.status
-	// 	});
-	// }
-	// if (!('protocols' in data) || data.protocols === undefined) {
-	// 	throw new TransactionServiceUpstreamError('Missing protocols in response', { status: 200 });
-	// }
-	const protocols = data as TransactionServiceExchange['protocols'];
-	if (protocols === null || typeof protocols !== 'object' || Array.isArray(protocols)) {
+	if (data === null || typeof data !== 'object' || Array.isArray(data)) {
 		throw new TransactionServiceUpstreamError('Missing protocols in response', { status: 200 });
 	}
+	const exchangeId = extractExchangeId(data);
+	const protocols = extractProtocols(data);
 
 	return {
-		// exchangeId: rawId,
-		exchangeId: 'TODO',
-		protocols: protocols as TransactionServiceExchange['protocols'],
+		exchangeId,
+		protocols,
 		expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString()
 	};
 }
@@ -137,4 +125,46 @@ function readTransactionServiceConfig(org: App.Organization): {
 		tenantName: ts.tenantName,
 		encryptedApiKey: ts.encryptedApiKey
 	};
+}
+
+/**
+ * Extract the exchange ID from the upstream response. Prefers a direct `id` field (for
+ * when the transaction service returns exchange detail fields). Falls back to parsing the
+ * last path segment of the `iu` interaction URL.
+ */
+function extractExchangeId(data: Record<string, unknown>): string {
+	if (typeof data.id === 'string' && data.id.length > 0) {
+		return data.id;
+	}
+	const protocols =
+		typeof data.protocols === 'object' && data.protocols !== null && !Array.isArray(data.protocols)
+			? (data.protocols as Record<string, unknown>)
+			: data;
+	if (typeof protocols.iu === 'string') {
+		try {
+			const lastSegment = new URL(protocols.iu).pathname.split('/').filter(Boolean).pop();
+			if (lastSegment) return lastSegment;
+		} catch {
+			// invalid URL — fall through to error
+		}
+	}
+	throw new TransactionServiceUpstreamError('Could not determine exchangeId from response', {
+		status: 200
+	});
+}
+
+/**
+ * Extract the protocols object from the upstream response. Handles both the current flat
+ * shape (`{ iu, vcapi, lcw, verifiablePresentationRequest }`) and a future nested shape
+ * (`{ protocols: { iu, ... } }`).
+ */
+function extractProtocols(data: Record<string, unknown>): TransactionServiceExchange['protocols'] {
+	const raw =
+		typeof data.protocols === 'object' && data.protocols !== null && !Array.isArray(data.protocols)
+			? (data.protocols as Record<string, unknown>)
+			: data;
+	if (typeof raw.iu !== 'string') {
+		throw new TransactionServiceUpstreamError('Missing protocols in response', { status: 200 });
+	}
+	return raw as TransactionServiceExchange['protocols'];
 }

--- a/src/routes/claims/[claimId]/exchange/server.test.ts
+++ b/src/routes/claims/[claimId]/exchange/server.test.ts
@@ -81,11 +81,11 @@ describe('POST /claims/[claimId]/exchange', () => {
 		mockIsExchangeEnabled.mockReturnValue(true);
 		mockFindUnique.mockResolvedValue(buildClaim());
 		mockCreateExchange.mockResolvedValue({
-			exchangeId: 'ex-1',
+			exchangeId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
 			protocols: {
-				iu: 'https://iu.example',
-				vcapi: 'https://v',
-				lcw: 'https://l',
+				iu: 'https://host.example/interactions/a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+				vcapi: 'https://host.example/workflows/claim/exchanges/a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+				lcw: 'https://lcw.app/request?vcapi=...',
 				verifiablePresentationRequest: {}
 			},
 			expiresAt: '2099-01-01T00:00:00.000Z'
@@ -193,7 +193,7 @@ describe('POST /claims/[claimId]/exchange', () => {
 		const res = (await POST(makeEvent())) as Response;
 		expect(res.ok).toBe(true);
 		const body = (await res.json()) as { exchangeId: string; protocols: { iu: string } };
-		expect(body.exchangeId).toBe('ex-1');
+		expect(body.exchangeId).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
 		expect(mockCreateExchange).toHaveBeenCalledTimes(1);
 		const vcArg = mockCreateExchange.mock.calls[0][1].vc as {
 			credentialSubject: Record<string, unknown>;


### PR DESCRIPTION
In the future, a transaction service may return a exchangeId in body of create exchange request via VCALM. Body is unspecified.

We do need to support Basic auth for this endpoint though.